### PR TITLE
Fixed namespace casing

### DIFF
--- a/src/Error/Exceptions/RecognitionException.php
+++ b/src/Error/Exceptions/RecognitionException.php
@@ -7,7 +7,7 @@
 namespace Antlr4\Error\Exceptions;
 
 use Antlr4\IntervalSet;
-use antlr4\IntStream;
+use Antlr4\IntStream;
 use Antlr4\Parser;
 use Antlr4\Token;
 

--- a/src/IntStream.php
+++ b/src/IntStream.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace antlr4;
+namespace Antlr4;
 
 /**
  * A simple stream of symbols whose values are represented as integers. This


### PR DESCRIPTION
Fixes the error 

> Case mismatch between loaded and declared class names: "Antlr4\IntStream" vs "antlr4\IntStream".